### PR TITLE
Fix bug when TrackingMST is instantiated from tracks only (no hits)

### DIFF
--- a/muograph/tracking/tracking.py
+++ b/muograph/tracking/tracking.py
@@ -743,7 +743,7 @@ class Tracking(AbsSave):
         The angular error between the generated and reconstructed tracks.
         """
         if self._angular_error is None:
-            if self.hits.spatial_res.sum() == 0.0:
+            if self.hits is None or self.hits.spatial_res.sum() == 0.0:
                 self._angular_error = torch.zeros_like(self.theta)
             else:
                 self._angular_error = self.get_angular_error(self.theta)


### PR DESCRIPTION
When TrackingMST is instantiated using only tracks, the method `angular_error` still tries to access the (nonexisting) hits to calculate the angular error.

Added a control to avoid this behaviour.

Tagging @jimenagomezf for her to follow eventual developments :)