### PR TITLE
Modified init, added optional argument "filename"

### DIFF
--- a/muograph/reconstruction/poca.py
+++ b/muograph/reconstruction/poca.py
@@ -59,7 +59,7 @@ class POCA(AbsSave, VoxelPlotting):
         voi: Optional[Volume] = None,
         poca_file: Optional[str] = None,
         output_dir: Optional[str] = None,
-        filename: Optional[str] = "poca"
+        filename: Optional[str] = "poca",
     ) -> None:
         r"""
         Initializes the POCA object with either an instance of the TrackingMST class or a
@@ -95,11 +95,11 @@ class POCA(AbsSave, VoxelPlotting):
             # Save attributes to hdf5
             if output_dir is not None:
                 self.save_attr(self._vars_to_save, self.output_dir, filename=self.filename)
-
+        
         # Load poca attributes from hdf5 if poca_file is provided
         elif tracking is None and poca_file is not None:
             self.load_attr(self._vars_to_load, poca_file)
-
+        self.filename = filename
     def __repr__(self) -> str:
         return f"Collection of {self.n_mu} POCA locations."
 

--- a/muograph/reconstruction/poca.py
+++ b/muograph/reconstruction/poca.py
@@ -95,11 +95,12 @@ class POCA(AbsSave, VoxelPlotting):
             # Save attributes to hdf5
             if output_dir is not None:
                 self.save_attr(self._vars_to_save, self.output_dir, filename=self.filename)
-        
+
         # Load poca attributes from hdf5 if poca_file is provided
         elif tracking is None and poca_file is not None:
             self.load_attr(self._vars_to_load, poca_file)
         self.filename = filename
+
     def __repr__(self) -> str:
         return f"Collection of {self.n_mu} POCA locations."
 

--- a/muograph/reconstruction/poca.py
+++ b/muograph/reconstruction/poca.py
@@ -73,6 +73,7 @@ class POCA(AbsSave, VoxelPlotting):
             poca_file (Optional[str]): The path to the poca.hdf5 to load attributes from.
             - output_dir (Optional[str]): Path to a directory where to save POCA attributes
             in a hdf5 file.
+            - filename (Optional[str]): name of the hdf5 file where POCA attributes will be saved if output_dir is filled
         """
         AbsSave.__init__(self, output_dir=output_dir)
         VoxelPlotting.__init__(self, voi)
@@ -94,7 +95,7 @@ class POCA(AbsSave, VoxelPlotting):
 
             # Save attributes to hdf5
             if output_dir is not None:
-                self.save_attr(self._vars_to_save, self.output_dir, filename=self.filename if self.filename else "poca")
+                self.save_attr(self._vars_to_save, self.output_dir, filename=self.filename if self.filename else "poca")  # type: ignore
 
         # Load poca attributes from hdf5 if poca_file is provided
         elif tracking is None and poca_file is not None:

--- a/muograph/reconstruction/poca.py
+++ b/muograph/reconstruction/poca.py
@@ -59,6 +59,7 @@ class POCA(AbsSave, VoxelPlotting):
         voi: Optional[Volume] = None,
         poca_file: Optional[str] = None,
         output_dir: Optional[str] = None,
+        filename: Optional[str] = "poca"
     ) -> None:
         r"""
         Initializes the POCA object with either an instance of the TrackingMST class or a
@@ -93,7 +94,7 @@ class POCA(AbsSave, VoxelPlotting):
 
             # Save attributes to hdf5
             if output_dir is not None:
-                self.save_attr(self._vars_to_save, self.output_dir, filename="poca")
+                self.save_attr(self._vars_to_save, self.output_dir, filename=self.filename)
 
         # Load poca attributes from hdf5 if poca_file is provided
         elif tracking is None and poca_file is not None:

--- a/muograph/reconstruction/poca.py
+++ b/muograph/reconstruction/poca.py
@@ -78,6 +78,8 @@ class POCA(AbsSave, VoxelPlotting):
         AbsSave.__init__(self, output_dir=output_dir)
         VoxelPlotting.__init__(self, voi)
 
+        self.filename = filename if filename else "poca"
+
         if tracking is None and poca_file is None:
             raise ValueError("Provide either poca.hdf5 file of TrackingMST instance.")
 
@@ -95,12 +97,11 @@ class POCA(AbsSave, VoxelPlotting):
 
             # Save attributes to hdf5
             if output_dir is not None:
-                self.save_attr(self._vars_to_save, self.output_dir, filename=self.filename if self.filename else "poca")  # type: ignore
+                self.save_attr(self._vars_to_save, self.output_dir, filename=self.filename)
 
         # Load poca attributes from hdf5 if poca_file is provided
         elif tracking is None and poca_file is not None:
             self.load_attr(self._vars_to_load, poca_file)
-        self.filename = filename
 
     def __repr__(self) -> str:
         return f"Collection of {self.n_mu} POCA locations."

--- a/muograph/reconstruction/poca.py
+++ b/muograph/reconstruction/poca.py
@@ -59,7 +59,7 @@ class POCA(AbsSave, VoxelPlotting):
         voi: Optional[Volume] = None,
         poca_file: Optional[str] = None,
         output_dir: Optional[str] = None,
-        filename: Optional[str] = "poca",
+        filename: Optional[str] = None,
     ) -> None:
         r"""
         Initializes the POCA object with either an instance of the TrackingMST class or a
@@ -94,7 +94,7 @@ class POCA(AbsSave, VoxelPlotting):
 
             # Save attributes to hdf5
             if output_dir is not None:
-                self.save_attr(self._vars_to_save, self.output_dir, filename=self.filename)
+                self.save_attr(self._vars_to_save, self.output_dir, filename=self.filename if self.filename else "poca")
 
         # Load poca attributes from hdf5 if poca_file is provided
         elif tracking is None and poca_file is not None:


### PR DESCRIPTION
In order to be able to inherit from poca and use poca and use the child class at the same time, filename must be configurable